### PR TITLE
[FEATURE] Synchronize Event Attendees, FreeBusy and Organizers

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,4 +116,10 @@ include.canceled.events=false
 #
 # Accepted value: true, false.
 include.event.body=false
+
+# Whether to include event attendees or not. When syncing from work Exchange calendar, sometimes it's
+# safer NOT to copy the attendees, which may include sensitive information, or due to work policy.
+#
+# Accepted value: true, false.
+include.event.attendees=false
 ```

--- a/src/main/groovy/com/github/choonchernlim/calsync/core/CalSyncEvent.groovy
+++ b/src/main/groovy/com/github/choonchernlim/calsync/core/CalSyncEvent.groovy
@@ -8,8 +8,9 @@ import org.joda.time.DateTime
  * Properties that this app cares across different calendar apps.
  *
  * Equals/HashCode allows a quick diff between calendar events.
+ * organizerAddress and organizerName are ignored, because Google might change the organizer to the current calendar
  */
-@EqualsAndHashCode(excludes = ['googleEventId', 'reminderMinutesBeforeStart'])
+@EqualsAndHashCode(excludes = ['googleEventId', 'organizerAddress', 'organizerName'])
 @ToString(includeNames = true)
 class CalSyncEvent {
     DateTime startDateTime
@@ -19,6 +20,22 @@ class CalSyncEvent {
     Integer reminderMinutesBeforeStart
     String body
     Boolean isAllDayEvent
+    List<Attendee> attendees
+    String organizerAddress
+    String organizerName
+    Boolean isBusy
 
     String googleEventId
+
+    @EqualsAndHashCode
+    static class Attendee {
+        String address
+        String name
+        Response response
+        Boolean isOptional
+
+        static enum Response {
+            ACCEPTED, DECLINED, TENTATIVE, NO_RESPONSE
+        }
+    }
 }

--- a/src/main/groovy/com/github/choonchernlim/calsync/core/ExchangeToGoogleService.groovy
+++ b/src/main/groovy/com/github/choonchernlim/calsync/core/ExchangeToGoogleService.groovy
@@ -46,7 +46,8 @@ class ExchangeToGoogleService {
                     startDateTime,
                     endDateTime,
                     userConfig.includeCanceledEvents,
-                    userConfig.includeEventBody)
+                    userConfig.includeEventBody,
+                    userConfig.includeEventAttendees)
         }
         catch (ServiceRequestException e) {
             // on connection exception, suppress exception if user says so

--- a/src/main/groovy/com/github/choonchernlim/calsync/core/UserConfig.groovy
+++ b/src/main/groovy/com/github/choonchernlim/calsync/core/UserConfig.groovy
@@ -17,4 +17,5 @@ class UserConfig {
     Integer nextSyncInMinutes
     Boolean includeCanceledEvents
     Boolean includeEventBody
+    Boolean includeEventAttendees
 }

--- a/src/main/groovy/com/github/choonchernlim/calsync/core/UserConfigReader.groovy
+++ b/src/main/groovy/com/github/choonchernlim/calsync/core/UserConfigReader.groovy
@@ -19,6 +19,7 @@ class UserConfigReader {
     static final String NEXT_SYNC_IN_MINUTES_KEY = 'next.sync.in.minutes'
     static final String INCLUDE_CANCELED_EVENTS_KEY = 'include.canceled.events'
     static final String INCLUDE_EVENT_BODY_KEY = 'include.event.body'
+    static final String INCLUDE_EVENT_ATTENDEES_KEY = 'include.event.attendees'
 
     /**
      * Returns user config.
@@ -82,6 +83,7 @@ class UserConfigReader {
 
         Boolean includeCanceledEvents = validatePropBoolean(props, errors, INCLUDE_CANCELED_EVENTS_KEY)
         Boolean includeEventBody = validatePropBoolean(props, errors, INCLUDE_EVENT_BODY_KEY)
+        Boolean includeEventAttendees = validatePropBoolean(props, errors, INCLUDE_EVENT_ATTENDEES_KEY)
 
         if (!errors.isEmpty()) {
             throw new CalSyncException(
@@ -99,7 +101,8 @@ class UserConfigReader {
                 totalSyncDays: totalSyncDays,
                 nextSyncInMinutes: nextSyncInMinutes,
                 includeCanceledEvents: includeCanceledEvents,
-                includeEventBody: includeEventBody
+                includeEventBody: includeEventBody,
+                includeEventAttendees: includeEventAttendees
         )
     }
 

--- a/src/main/groovy/com/github/choonchernlim/calsync/exchange/ExchangeEvent.groovy
+++ b/src/main/groovy/com/github/choonchernlim/calsync/exchange/ExchangeEvent.groovy
@@ -9,8 +9,20 @@ class ExchangeEvent {
     DateTime endDateTime
     String subject
     String location
+    Boolean isReminderSet
     Integer reminderMinutesBeforeStart
     String body
     Boolean isCanceled
     Boolean isAllDayEvent
+    List<Attendee> optionalAttendees
+    List<Attendee> requiredAttendees
+    String organizerAddress
+    String organizerName
+    Boolean isBusy
+
+    static class Attendee {
+        String address
+        String name
+        String response
+    }
 }

--- a/src/main/groovy/com/github/choonchernlim/calsync/exchange/ExchangeService.groovy
+++ b/src/main/groovy/com/github/choonchernlim/calsync/exchange/ExchangeService.groovy
@@ -40,10 +40,12 @@ class ExchangeService {
             DateTime startDateTime,
             DateTime endDateTime,
             Boolean includeCanceledEvents,
-            Boolean includeEventBody) {
+            Boolean includeEventBody,
+            Boolean includeAttendees) {
         assert startDateTime && endDateTime && startDateTime <= endDateTime
         assert includeCanceledEvents != null
         assert includeEventBody != null
+        assert includeAttendees != null
 
         LOGGER.info(
                 "Retrieving events from ${Mapper.humanReadableDateTime(startDateTime)} to ${Mapper.humanReadableDateTime(endDateTime)}...")
@@ -57,7 +59,7 @@ class ExchangeService {
             LOGGER.info("\tTotal events after excluding canceled events: ${exchangeEvents.size()}...")
         }
 
-        return exchangeEvents.collect { Mapper.toCalSyncEvent(it, includeEventBody) }
+        return exchangeEvents.collect { Mapper.toCalSyncEvent(it, includeEventBody, includeAttendees) }
     }
 }
 

--- a/src/main/resources/calsync-sample.conf
+++ b/src/main/resources/calsync-sample.conf
@@ -59,3 +59,9 @@ include.canceled.events=false
 #
 # Accepted value: true, false.
 include.event.body=false
+
+# Whether to include event attendees or not. When syncing from work Exchange calendar, sometimes it's
+# safer NOT to copy the attendees, which may include sensitive information, or due to work policy.
+#
+# Accepted value: true, false.
+include.event.attendees=false


### PR DESCRIPTION
This change introduces the ability to also synchronize the attendees of an event including their responses (accept, decline, ...) to the event. This also includes the organizer of such events and whether the event has been marked as being free/transparent or busy/opaque. I added an configuration option too.

There were some pitfalls that had to be considered:
- Google might ignore the `organizerAddress` and `organizerName` fields when there are no additional attendees and change them to `somecalendaremail@calendar.google.com` and `TheCalendarName`.
- Attendee email addresses are automatically lowercased by Google.
- Attendee lists might be reordered by Google.

There also was a bug that would create a reminder in Google Calendar even though it was not supposed to be. Exchange returns a duration in `ReminderMinutesBeforeStart`, but `IsReminderSet` also has to be considered because it might be `false`.

I will add tests if there is an intention to merge this.